### PR TITLE
ofxSmartOscSender: add sendMessage with const arg

### DIFF
--- a/src/ofxSmartOscSender.h
+++ b/src/ofxSmartOscSender.h
@@ -80,10 +80,6 @@ namespace bbb {
             return wrapInBundle;
         }
 
-        void sendMessage(ofxOscMessage &m) {
-            ofxOscSender::sendMessage(m, wrapInBundle);
-        }
-        
         void sendMessage(const ofxOscMessage &m) {
             ofxOscSender::sendMessage(m, wrapInBundle);
         }

--- a/src/ofxSmartOscSender.h
+++ b/src/ofxSmartOscSender.h
@@ -84,6 +84,10 @@ namespace bbb {
             ofxOscSender::sendMessage(m, wrapInBundle);
         }
         
+        void sendMessage(const ofxOscMessage &m) {
+            ofxOscSender::sendMessage(m, wrapInBundle);
+        }
+        
         template <typename ... Args>
         inline void send(const std::string &address, const Args & ... args) {
             static_assert(sizeof...(args) != 0, "args is null at send");


### PR DESCRIPTION
I get const ofxOscMessage from ofxOscReceiver (making a sort of "relay" function).

there is a complaint about dropping const when using sendMessage(); added a const-flavored method.

maybe there's a more correct way of doing this?